### PR TITLE
Added idle timeout to ScreenTitleJoin

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -112,6 +112,8 @@ FooterOnCommand=visible,false
 # this is for when we are in Free/Pay mode
 [ScreenTitleJoin]
 Fallback="ScreenTitleMenu"
+IdleTimeoutSeconds=30
+IdleTimeoutScreen="ScreenInit"
 ChoiceNames="1"
 Choice1="applydefaultoptions;screen,"..Branch.AllowScreenSelectProfile()..";text,Dance Mode"
 # Choice2="screen,ScreenUnlock;text,Enter Unlock Code"


### PR DESCRIPTION
One of the things I noticed while running through the motions of setting up a public image was that if the machine is left on the "Press Start" screen AKA ScreenTitleJoin while in FreePlay or Coin, the game stuck there.

This was odd to me as I expected if the player pressed a button in FreePlay, pushing the game to this screen, then walked away, after a certain period of time the game would go back to running the Attract sequence.

This wasn't the case and I did a little digging to notice the "IdleTimeoutSeconds" was set in the Home screen (ScreenTitleMenu), but no the FreePlay/Coin screen (ScreenTitleJoin).

So as discussed, here's the PR.

Dan, thank you for everything you do on this project. You really do not give yourself enough credit.